### PR TITLE
Load model from volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # llvm-inference
+
+This project provides a simple example of running the Qwen3 reranker model with [vLLM](https://github.com/vllm-project/vllm) and a small ASP.NET web application.
+
+## Local model
+
+The Python service expects the model and tokenizer files to be available locally. Copy the contents of the `Qwen/Qwen3-Reranker-0.6B` repository into:
+
+```
+models/Qwen3-Reranker-0.6B
+```
+
+Docker mounts this directory into the container at `/models` and the service loads the model from `MODEL_DIR=/models/Qwen3-Reranker-0.6B`.
+
+## Building the images
+
+To build the Python service image manually run:
+
+```bash
+docker build -t llvm-vllm-service ./vllm-service
+```
+
+The web application can be built with Docker Compose or individually in a similar way.
+
+## Running locally
+
+After placing the model files, start the stack with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+This starts the `vllm-service` on port `8000` and the ASP.NET frontend on port `8080`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,12 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - VLLM_USE_CPU=1
+      - MODEL_DIR=/models/Qwen3-Reranker-0.6B
       # Increase memory limits for CPU inference
       - OMP_NUM_THREADS=4
       - MKL_NUM_THREADS=4
     volumes:
-      - ./models:/root/.cache/huggingface
+      - ./models:/models
     # Remove GPU resource requirements
     # deploy:
     #   resources:

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,2 @@
+This directory should contain the pre-downloaded `Qwen3-Reranker-0.6B` model.
+Place the model files under `models/Qwen3-Reranker-0.6B` so that Docker can load them without Internet access.

--- a/vllm-service/main.py
+++ b/vllm-service/main.py
@@ -1,3 +1,4 @@
+import os
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 import torch
@@ -53,14 +54,22 @@ async def startup_event():
     global model, tokenizer, sampling_params, token_false_id, token_true_id
     
     logger.info("Loading model and tokenizer for CPU inference...")
+
+    # Read model directory from environment or use default
+    model_dir = os.getenv("MODEL_DIR", "/models/Qwen3-Reranker-0.6B")
+    logger.info(f"Using model directory: {model_dir}")
     
     try:
-        # Initialize tokenizer
-        tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-Reranker-0.6B")
+        # Initialize tokenizer from local path
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_dir,
+            trust_remote_code=True,
+            local_files_only=True
+        )
         
         # Initialize vLLM model for CPU inference
         model = LLM(
-            model="Qwen/Qwen3-Reranker-0.6B",
+            model=model_dir,
             tensor_parallel_size=1,
             # Remove GPU-specific settings
             # gpu_memory_utilization=0.8,


### PR DESCRIPTION
## Summary
- load tokenizer and model from local MODEL_DIR path
- mount models directory inside `vllm-service`
- document how to provide the model and build images
- add a short models README

## Testing
- `python -m py_compile vllm-service/main.py`
- `dotnet build web-app/InferenceLlvm/InferenceLlvm.csproj -c Release` *(fails: command not found)*
- `docker build -t test ./vllm-service` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc7257fec8323b3cfeaac9a9e8dfe